### PR TITLE
Improvements for buttons

### DIFF
--- a/docs/_includes/badges.md
+++ b/docs/_includes/badges.md
@@ -1,19 +1,19 @@
 # Badges
 
 {% example html %}
-<button class="btn btn-default" type="button">
+<button class="btn" type="button">
     Default <span class="badge">10</span>
 </button>
-<button class="btn btn-default" type="button">
+<button class="btn" type="button">
     Warning <span class="badge badge-warning">10</span>
 </button>
-<button class="btn btn-default" type="button">
+<button class="btn" type="button">
     Danger <span class="badge badge-danger">10</span>
 </button>
-<button class="btn btn-default" type="button">
+<button class="btn" type="button">
     Success <span class="badge badge-success">10</span>
 </button>
-<button class="btn btn-default" type="button">
+<button class="btn" type="button">
     Info <span class="badge badge-info">10</span>
 </button>
 {% endexample %}

--- a/docs/_includes/button-groups.md
+++ b/docs/_includes/button-groups.md
@@ -23,7 +23,7 @@ Toolbars can contain multiple group of buttons:
     </div>
     <div class="btn-group">
         <button class="btn" type="button">Star</button>
-        <a class="btn btn-outline" href="#" role="button">0</a>
+        <a class="btn btn-count" href="#" role="button">0</a>
     </div>
 </div>
 {% endexample %}

--- a/docs/_includes/button-groups.md
+++ b/docs/_includes/button-groups.md
@@ -4,8 +4,8 @@ Button groups and toolbars are used to group actions together.
 
 {% example html %}
 <div class="btn-group">
-    <button class="btn btn-default" type="button">Button button</button>
-    <a class="btn btn-default" href="#" role="button">Link button</a>
+    <button class="btn" type="button">Button button</button>
+    <a class="btn" href="#" role="button">Link button</a>
 </div>
 {% endexample %}
 
@@ -14,15 +14,15 @@ Toolbars can contain multiple group of buttons:
 {% example html %}
 <div class="btn-toolbar">
     <div class="btn-group">
-        <button class="btn btn-default" type="button">Button button</button>
-        <a class="btn btn-default" href="#" role="button">Link button</a>
+        <button class="btn" type="button">Button button</button>
+        <a class="btn" href="#" role="button">Link button</a>
     </div>
     <div class="btn-group">
         <button class="btn btn-danger" type="button">Danger button</button>
         <a class="btn btn-success" href="#" role="button">Success button</a>
     </div>
     <div class="btn-group">
-        <button class="btn btn-default" type="button">Star</button>
+        <button class="btn" type="button">Star</button>
         <a class="btn btn-outline" href="#" role="button">0</a>
     </div>
 </div>

--- a/docs/_includes/buttons.md
+++ b/docs/_includes/buttons.md
@@ -26,25 +26,25 @@ Buttons are availables in multiples sizes: Large, Normal, Small and Extra-Small.
 
 ### Styles
 
-Different styles of buttons are available to indicate different kind of actions.
+Buttons can be filled to indicate a more important action:
 
 {% example html %}
 <button class="btn btn-primary" type="button">Primary button</button>
 <button class="btn btn-success" type="button">Success button</button>
 <button class="btn btn-danger" type="button">Danger button</button>
 <button class="btn btn-warning" type="button">Warning button</button>
-<button class="btn btn-link" type="button">Link button</button>
 {% endexample %}
 
-### Filled Buttons
+### Colored Text
 
-Buttons can be filled to indicate a more important action, using `.btn-fill`.
+Different styles of buttons are available to indicate different kind of actions.
 
 {% example html %}
-<button class="btn btn-primary btn-fill" type="button">Primary button</button>
-<button class="btn btn-success btn-fill" type="button">Success button</button>
-<button class="btn btn-danger btn-fill" type="button">Danger button</button>
-<button class="btn btn-warning btn-fill" type="button">Warning button</button>
+<button class="btn btn-text-primary" type="button">Primary button</button>
+<button class="btn btn-text-success" type="button">Success button</button>
+<button class="btn btn-text-danger" type="button">Danger button</button>
+<button class="btn btn-text-warning" type="button">Warning button</button>
+<button class="btn btn-link" type="button">Link button</button>
 {% endexample %}
 
 ### Block Buttons
@@ -52,7 +52,7 @@ Buttons can be filled to indicate a more important action, using `.btn-fill`.
 Create block level buttons—those that span the full width of a parent— by adding `.btn-block`.
 
 {% example html %}
-<button type="button" class="btn btn-primary btn-fill btn-lg btn-block">Block level button</button>
+<button type="button" class="btn btn-primary btn-lg btn-block">Block level button</button>
 <button type="button" class="btn btn-default btn-lg btn-block">Block level button</button>
 {% endexample %}
 
@@ -67,9 +67,9 @@ Buttons can have different states:
     <button class="btn btn-default" disabled type="button">:disabled or .disabled</button>
 </div>
 <div class="btn-toolbar">
-    <button class="btn btn-primary btn-fill" type="button">Default</button>
-    <button class="btn btn-primary btn-fill active" type="button">:active or .active</button>
-    <button class="btn btn-primary btn-fill" disabled type="button">:disabled or .disabled</button>
+    <button class="btn btn-primary" type="button">Default</button>
+    <button class="btn btn-primary active" type="button">:active or .active</button>
+    <button class="btn btn-primary" disabled type="button">:disabled or .disabled</button>
 </div>
 {% endexample %}
 
@@ -78,7 +78,7 @@ Buttons can have different states:
 Buttons can contains a new-line label:
 
 {% example html %}
-<button class="btn btn-primary btn-fill btn-block" type="button">
+<button class="btn btn-primary btn-block" type="button">
     Download for OS X
     <span class="btn-label">OS X 10.9 or later</span>
 </button>

--- a/docs/_includes/buttons.md
+++ b/docs/_includes/buttons.md
@@ -61,11 +61,23 @@ Create block level buttons—those that span the full width of a parent— by ad
 Outline buttons downplay an action as they appear like boxy links. Just add `.btn-outline` and go.
 
 {% example html %}
-<button class="btn btn-outline" type="button">Default button</button>
+<button class="btn btn-count" type="button">Default button</button>
 <button class="btn btn-primary btn-outline" type="button">Primary button</button>
 <button class="btn btn-success btn-outline" type="button">Success button</button>
 <button class="btn btn-danger btn-outline" type="button">Danger button</button>
 <button class="btn btn-warning btn-outline" type="button">Warning button</button>
+{% endexample %}
+
+### Plain
+
+Plain buttons are flat and filled buttons.
+
+{% example html %}
+<button class="btn btn-plain" type="button">Default button</button>
+<button class="btn btn-primary btn-plain" type="button">Primary button</button>
+<button class="btn btn-success btn-plain" type="button">Success button</button>
+<button class="btn btn-danger btn-plain" type="button">Danger button</button>
+<button class="btn btn-warning btn-plain" type="button">Warning button</button>
 {% endexample %}
 
 ### States

--- a/docs/_includes/buttons.md
+++ b/docs/_includes/buttons.md
@@ -9,8 +9,8 @@ Use the standard—yet classy—`.btn` for form actions and primary page actions
 When using a `<button>` element, **always specify a `type`**. When using a `<a>` element, **always add `role="button"` for accessibility**.
 
 {% example html %}
-<button class="btn btn-default" type="button">Button button</button>
-<a class="btn btn-default" href="#" role="button">Link button</a>
+<button class="btn" type="button">Button button</button>
+<a class="btn" href="#" role="button">Link button</a>
 {% endexample %}
 
 ### Sizes
@@ -18,10 +18,10 @@ When using a `<button>` element, **always specify a `type`**. When using a `<a>`
 Buttons are availables in multiples sizes: Large, Normal, Small and Extra-Small.
 
 {% example html %}
-<button class="btn btn-default btn-lg" type="button">Large Button</button>
-<button class="btn btn-default" type="button">Button</button>
-<button class="btn btn-default btn-sm" type="button">Small button</button>
-<button class="btn btn-default btn-xs" type="button">Extra Small button</button>
+<button class="btn btn-lg" type="button">Large Button</button>
+<button class="btn" type="button">Button</button>
+<button class="btn btn-sm" type="button">Small button</button>
+<button class="btn btn-xs" type="button">Extra Small button</button>
 {% endexample %}
 
 ### Styles
@@ -53,7 +53,19 @@ Create block level buttons—those that span the full width of a parent— by ad
 
 {% example html %}
 <button type="button" class="btn btn-primary btn-lg btn-block">Block level button</button>
-<button type="button" class="btn btn-default btn-lg btn-block">Block level button</button>
+<button type="button" class="btn btn-lg btn-block">Block level button</button>
+{% endexample %}
+
+### Outline
+
+Outline buttons downplay an action as they appear like boxy links. Just add `.btn-outline` and go.
+
+{% example html %}
+<button class="btn btn-outline" type="button">Default button</button>
+<button class="btn btn-primary btn-outline" type="button">Primary button</button>
+<button class="btn btn-success btn-outline" type="button">Success button</button>
+<button class="btn btn-danger btn-outline" type="button">Danger button</button>
+<button class="btn btn-warning btn-outline" type="button">Warning button</button>
 {% endexample %}
 
 ### States
@@ -62,9 +74,9 @@ Buttons can have different states:
 
 {% example html %}
 <div class="btn-toolbar">
-    <button class="btn btn-default" type="button">Default</button>
-    <button class="btn btn-default active" type="button">:active or .active</button>
-    <button class="btn btn-default" disabled type="button">:disabled or .disabled</button>
+    <button class="btn" type="button">Default</button>
+    <button class="btn active" type="button">:active or .active</button>
+    <button class="btn" disabled type="button">:disabled or .disabled</button>
 </div>
 <div class="btn-toolbar">
     <button class="btn btn-primary" type="button">Default</button>

--- a/docs/_includes/dropdowns.md
+++ b/docs/_includes/dropdowns.md
@@ -4,7 +4,7 @@ Dropdown menu can be added to `.btn-group`.
 
 {% example html %}
 <div class="btn-group dropdown">
-    <button class="btn btn-default" type="button">Toggle Dropdown <span class="dropdown-caret"></span></button>
+    <button class="btn" type="button">Toggle Dropdown <span class="dropdown-caret"></span></button>
     <ul class="dropdown-menu open">
         <li class="dropdown-header">This is an header</li>
         <li><a href="#">Entry 1</a></li>
@@ -30,13 +30,13 @@ Dropdown menu can be added to `.btn-group`.
 
 {% example html %}
 <div class="btn-group pull-left dropdown">
-    <button class="btn btn-default" type="button">Left</button>
+    <button class="btn" type="button">Left</button>
     <ul class="dropdown-menu open">
         <li><a href="#">This is a long entry</a></li>
     </ul>
 </div>
 <div class="btn-group pull-right dropdown">
-    <button class="btn btn-default" type="button">Right</button>
+    <button class="btn" type="button">Right</button>
     <ul class="dropdown-menu open">
         <li><a href="#">This is a long entry <span class="help-label">Help Text</span></a></li>
     </ul>

--- a/docs/_includes/forms.md
+++ b/docs/_includes/forms.md
@@ -27,7 +27,7 @@
             <input type="checkbox"> Check me out
         </label>
     </div>
-    <button type="submit" class="btn btn-default">Submit</button>
+    <button type="submit" class="btn">Submit</button>
 </form>
 {% endexample %}
 
@@ -94,7 +94,7 @@ Extend form controls by adding text or buttons before, after, or on both sides o
         </span>
         <input type="text" class="form-control" placeholder="Please type in the username.">
         <span class="input-group-btn">
-            <button class="btn btn-default" type="submit">Delete</button>
+            <button class="btn" type="submit">Delete</button>
         </span>
     </div>
 </div>

--- a/docs/_includes/modals.md
+++ b/docs/_includes/modals.md
@@ -12,7 +12,7 @@ Modal (`.modal`) can be used in 3 sizes: medium (default), small (`.modal-sm`) a
         Body of the modal
     </div>
     <div class="modal-footer">
-        <button class="btn btn-default">Close</button>
+        <button class="btn">Close</button>
     </div>
 </div>
 {% endexample %}

--- a/docs/_includes/tooltips.md
+++ b/docs/_includes/tooltips.md
@@ -5,9 +5,9 @@ Add tooltips built entirely in CSS to nearly any element. Just add a few classes
 Remember, `aria-label` and tooltip classes must go directly on `<button>` and `<a>` elements. Tooltip classes also conflict with icon classes, and as such, must go on a parent element instead of the icon.
 
 {% example html %}
-<button class="btn btn-default tooltipped tooltipped-o" aria-label="Bottom, right (default)" type="button">Button</button>
-<button class="btn btn-default tooltipped tooltipped-nw tooltipped-o" aria-label="Top, left" type="button">.tooltipped-nw</button>
-<button class="btn btn-default tooltipped tooltipped-w tooltipped-o" aria-label="Bottom, left" type="button">.tooltipped-w</button>
-<button class="btn btn-default tooltipped tooltipped-ne tooltipped-o" aria-label="Top, right" type="button">.tooltipped-ne</button>
+<button class="btn tooltipped tooltipped-o" aria-label="Bottom, right (default)" type="button">Button</button>
+<button class="btn tooltipped tooltipped-nw tooltipped-o" aria-label="Top, left" type="button">.tooltipped-nw</button>
+<button class="btn tooltipped tooltipped-w tooltipped-o" aria-label="Bottom, left" type="button">.tooltipped-w</button>
+<button class="btn tooltipped tooltipped-ne tooltipped-o" aria-label="Top, right" type="button">.tooltipped-ne</button>
 {% endexample %}
 

--- a/less/components/buttons.less
+++ b/less/components/buttons.less
@@ -6,13 +6,13 @@
 }
 
 .button(@mainColor) {
-    background: linear-gradient(@mainColor, darken(@mainColor, 10%));
-    border-color: darken(@mainColor, 15%);
+    background: linear-gradient(@mainColor, darken(@mainColor, @gb-button-gradient));
+    border-color: darken(@mainColor, 1.5 * @gb-button-gradient);
     color: #fff;
 
     &:hover, &:focus {
-        background: linear-gradient(@mainColor, darken(@mainColor, 15%));
-        border-color: darken(@mainColor, 20%);
+        background: linear-gradient(@mainColor, darken(@mainColor, 1.5 * @gb-button-gradient));
+        border-color: darken(@mainColor, 2 * @gb-button-gradient);
     }
 
     .caret {
@@ -37,7 +37,42 @@
 // Create new class of button
 .button-class(@className, @mainColor) {
     &.btn-@{className} {
-        .button(@mainColor)
+        .button(@mainColor);
+
+        &.btn-plain {
+            background: @mainColor;
+            border-color: @mainColor;
+            color: #fff;
+
+            .caret {
+                border-top-color: #fff;
+            }
+
+            &:hover, &:focus {
+                background: darken(@mainColor, 1.5 * @gb-button-gradient);
+                border-color: darken(@mainColor, 1.5 * @gb-button-gradient);
+                color: #fff;
+            }
+        }
+
+        &.btn-outline {
+            background: #fff;
+            color: @mainColor;
+            border-color: @mainColor;
+
+            .caret {
+                border-top-color: @mainColor;
+            }
+
+            &:hover, &:focus {
+                background: @mainColor;
+                color: #fff;
+
+                .caret {
+                    border-top-color: #fff;
+                }
+            }
+        }
     }
 
     &.btn-text-@{className} {
@@ -63,8 +98,8 @@
 
     // Hover and focus
     &:hover, &:focus, &.dropdown-toggle.open {
-        background: linear-gradient(@gb-button-background, darken(@gb-button-background, 10%));
-        border-color: darken(@gb-button-background, 20%);
+        background: linear-gradient(@gb-button-background, darken(@gb-button-background, @gb-button-gradient));
+        border-color: darken(@gb-button-background, 2 * @gb-button-gradient);
         .box-shadow(none);
         outline: none;
         text-decoration: none;
@@ -117,7 +152,6 @@
         }
     }
 
-
     /// Styles
     &.btn-link {
         .button(@gb-link-color);
@@ -130,8 +164,18 @@
         }
     }
 
-    &.btn-outline {
-        .button(#fff);
+    &.btn-plain {
+        background: @gb-button-background;
+        border-color: @gb-button-background;
+
+        &:hover, &:focus {
+            background: darken(@gb-button-background, 1.5 * @gb-button-gradient);
+            border-color: darken(@gb-button-background, 1.5 * @gb-button-gradient);
+        }
+    }
+
+    &.btn-count {
+        background: #fff;
         color: @gb-body-color;
         background: #fff;
 

--- a/less/components/buttons.less
+++ b/less/components/buttons.less
@@ -6,16 +6,60 @@
 }
 
 .button(@mainColor) {
+    background: linear-gradient(@mainColor, darken(@mainColor, 10%));
+    border-color: darken(@mainColor, 15%);
+    color: #fff;
+
+    &:hover, &:focus {
+        background: linear-gradient(@mainColor, darken(@mainColor, 15%));
+        border-color: darken(@mainColor, 20%);
+    }
+
+    .caret {
+        border-top-color: @mainColor;
+    }
+
+    &.btn-noborder, &.btn-link {
+        text-shadow: none;
+        color: @mainColor;
+        border: none;
+        background: none;
+        .box-shadow(none);
+
+        &:hover, &:focus {
+            color: darken(@mainColor, 12%);
+            outline: none;
+        }
+    }
+}
+
+
+// Create new class of button
+.button-class(@className, @mainColor) {
+    &.btn-@{className} {
+        .button(@mainColor)
+    }
+
+    &.btn-text-@{className} {
+        color: @mainColor;
+    }
+}
+
+.btn, a.btn, .gb-markdown .btn {
     text-shadow: none;
     border-radius: @gb-border-radius-base;
     background: linear-gradient(@gb-button-background, darken(@gb-button-background, 6%));
     border: 1px solid @gb-button-border;
-    color: @mainColor;
+    color: @gb-body-color;
     .box-shadow(none);
     text-decoration: none;
     text-shadow: none;
     cursor: pointer;
     display: inline-block;
+
+    .caret {
+        border-top-color: @gb-body-color;
+    }
 
     // Hover and focus
     &:hover, &:focus, &.dropdown-toggle.open {
@@ -46,37 +90,6 @@
         }
     }
 
-    .caret {
-        border-top-color: @mainColor;
-    }
-
-    &.btn-noborder, &.btn-link {
-        text-shadow: none;
-        color: @mainColor;
-        border: none;
-        background: none;
-        .box-shadow(none);
-
-        &:hover, &:focus {
-            color: darken(@mainColor, 12%);
-            outline: none;
-        }
-    }
-
-    &.btn-fill {
-        background: linear-gradient(@mainColor, darken(@mainColor, 10%));
-        border-color: darken(@mainColor, 15%);
-        color: #fff;
-
-        &:hover, &:focus {
-            background: linear-gradient(@mainColor, darken(@mainColor, 15%));
-            border-color: darken(@mainColor, 20%);
-        }
-    }
-}
-
-
-.btn {
     .button-size(@gb-padding-base-vertical; @gb-padding-base-horizontal;
         @gb-font-size-base; @gb-line-height-base; @gb-border-radius-base);
 
@@ -117,15 +130,6 @@
         }
     }
 
-    &.btn-default {
-        .button(#fcfcfc);
-        color: @gb-body-color;
-
-        .caret {
-            border-top-color: @gb-body-color;
-        }
-    }
-
     &.btn-outline {
         .button(#fff);
         color: @gb-body-color;
@@ -145,21 +149,11 @@
         }
     }
 
-    &.btn-success {
-        .button(@gb-brand-success);
-    }
-    &.btn-primary {
-        .button(@gb-brand-primary);
-    }
-    &.btn-warning {
-        .button(@gb-brand-warning);
-    }
-    &.btn-danger {
-        .button(@gb-brand-danger);
-    }
-    &.btn-info {
-        .button(@gb-brand-info);
-    }
+    .button-class(success, @gb-brand-success);
+    .button-class(primary, @gb-brand-primary);
+    .button-class(warning, @gb-brand-warning);
+    .button-class(danger, @gb-brand-danger);
+    .button-class(info, @gb-brand-info);
 
 
     // Label for buttons

--- a/less/components/forms.less
+++ b/less/components/forms.less
@@ -43,7 +43,7 @@
 
 // Select
 select.form-control {
-    .btn.btn-default();
+    .btn();
     display: inline-block;
     -webkit-appearance: none;
     -moz-appearance: none;

--- a/less/variables.less
+++ b/less/variables.less
@@ -135,6 +135,7 @@
 ///
 @gb-button-background:             @gb-palette-gray-light;
 @gb-button-border:                 darken(@gb-button-background, 20%);
+@gb-button-gradient:               10%;
 
 ///
 /// Forms


### PR DESCRIPTION
- [x] Remove `.btn-fill`, buttons are filled by default
- [x] Add `btn-text-{style}` to replace previous default state
- [x] Remove `btn-default`
- [x] Add `btn-plain` for flat buttons
- [x] New `btn-outline`
- [x] `btn-count` replace `btn-outline`
