### PR TITLE
clarifying link/button confusion

### DIFF
--- a/docs/buttons.md
+++ b/docs/buttons.md
@@ -12,11 +12,15 @@ Buttons are used for **actions**, like in forms, while textual hyperlinks are us
 
 Use the standard—yet classy—`.btn` for form actions and primary page actions. These are used extensively around the site.
 
-When using a `<button>` element, **always specify a `type`**. When using a `<a>` element, **always add `role="button"` for accessibility**.
+When using a `<button>` element, **always specify a `type`**.
 
 {% example html %}
 <button class="btn" type="button">Button button</button>
-<a class="btn" href="#" role="button">Link button</a>
+{% endexample %}
+
+A link can be made to look like a button by adding `.btn` to a `<a>` element.
+{% example html %}
+<a class="btn" href="">Link styled as a button</a>
 {% endexample %}
 
 ### Sizes


### PR DESCRIPTION
Adding role="button" to a link doesn't make it act like a button. Removing recommendation to add role="button" to links. The role an element has should reflect its function; not its visual appearance.

It's okay to have links look like buttons, but the practice of repurposing links to act like buttons should not be encouraged. Even if some button functionality is added to the links (e.g. activated with Space Bar), it can be confusing if link functionality (e.g. 'open in new tab' in context menu) is not also removed. Using buttons as buttons should be encouraged.