### PR TITLE
Add doc example for Buttons with labels

### DIFF
--- a/pages/buttons.js
+++ b/pages/buttons.js
@@ -53,6 +53,13 @@ const EXAMPLE_STATES =
     <Button style="primary" disabled>Disabled</Button>
 </Button.Toolbar>`;
 
+const EXAMPLE_LABELS =
+`<Button.Toolbar>
+    <Button title="Label">Default</Button>
+    <Button title="Label" active>Active</Button>
+    <Button title="Label" disabled>Disabled</Button>
+</Button.Toolbar>`;
+
 const EXAMPLE_BLOCK =
 `<Button block style="primary">Primary block button</Button>
 <Button block>Secondary button</Button>`;
@@ -102,6 +109,10 @@ export default () => {
 
             <Example title="States" source={EXAMPLE_STATES} scope={SCOPE}>
                 Buttons can have different states:
+            </Example>
+
+            <Example title="Labels" source={EXAMPLE_LABELS} scope={SCOPE}>
+                Buttons can have a label on hover:
             </Example>
 
             <Example title="Block buttons" source={EXAMPLE_BLOCK} scope={SCOPE}>

--- a/pages/tooltips.js
+++ b/pages/tooltips.js
@@ -41,12 +41,6 @@ const EXAMPLE_POSITIONS =
     <code>Top</code>
 </Tooltip>`;
 
-const EXAMPLE_BUTTONS =
-`<Button.Toolbar>
-    <Button title="Hello 1">Do something</Button>
-    <Button title="Hello 2">Else</Button>
-</Button.Toolbar>`;
-
 export default () => {
     return (
         <Page title="Tooltips" active="tooltips">
@@ -59,7 +53,6 @@ export default () => {
 
             <Example title="Example" source={EXAMPLE_DEFAULT} scope={SCOPE}></Example>
             <Example title="Positions" source={EXAMPLE_POSITIONS} scope={SCOPE}></Example>
-            <Example title="Buttons" source={EXAMPLE_BUTTONS} scope={SCOPE}></Example>
         </Page>
     );
 };


### PR DESCRIPTION

![screen shot 2016-11-24 at 11 17 41](https://cloud.githubusercontent.com/assets/5644953/20594738/a60ce0e0-b237-11e6-9273-c9b96488cc27.png)



I think disabled buttons should still have a label on hover, as it is now in 7.0.0 (unlike in 6.x.x). We still see they are disabled from the opacity and non pointer cursor, and we don't lose that label in case we don't understand what the button means. This is useful for example there https://github.com/GitbookIO/editor/pull/395