### PR TITLE
Fixes #36 More obvious disabled buttons

### DIFF
--- a/less/components/buttons.less
+++ b/less/components/buttons.less
@@ -147,8 +147,8 @@
 
     &.disabled, &.disabled:hover {
         color: #fff;
-        background: fadeout(@color, @gb-button-disabled-fadeout);
-        border-color: fadeout(@color, @gb-button-disabled-fadeout);
+        background: tint(@color, @gb-button-disabled-fadeout);
+        border-color: tint(@color, @gb-button-disabled-fadeout);
     }
 }
 

--- a/less/variables.less
+++ b/less/variables.less
@@ -155,7 +155,7 @@
 @gb-button-plain-background:       #eee;
 @gb-button-border:                 @gb-palette-gray-outline;
 @gb-button-gradient:               10%;
-@gb-button-disabled-fadeout:       25%;
+@gb-button-disabled-fadeout:       50%;
 @gb-button-hover-background:       #f6f7f8;
 
 ///


### PR DESCRIPTION
Fixes #36 

Don't use transparency, to avoid border effect. And make disabled more obvious.

<img width="249" alt="screen shot 2016-12-17 at 19 02 55" src="https://cloud.githubusercontent.com/assets/5644953/21288776/eb539174-c48b-11e6-9ff7-8218305590ff.png">
