### PR TITLE
Fix rerendering of props when groups / options change

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -145,7 +145,7 @@ const Select = React.createClass({
      * @return {Array<groupShape>}
      */
     propsToGroups(props) {
-        const { options, groups } = this.props;
+        const { options, groups } = props;
 
         if (groups) {
             return groups;


### PR DESCRIPTION
This fix a rendering issue when groups / options props changes. This method `propsToGroups` is used in `componentWillReceiveProps` which previously was checking against `this.props` vs now `newProps`