### PR TITLE
Add positions for Popover

### DIFF
--- a/less/components/alerts.less
+++ b/less/components/alerts.less
@@ -1,6 +1,6 @@
 .alert {
     border: 1px solid @gb-palette-gray-outline;
-    background: @gb-palette-gray;
+    background: @gb-palette-gray-light;
     border-radius: @gb-alert-radius;
     padding: @gb-alert-padding;
     margin-bottom: @gb-alert-margin;

--- a/less/components/popover.less
+++ b/less/components/popover.less
@@ -88,37 +88,51 @@
     }
 }
 
-.popover-top .popover-arrow {
-    bottom: -@gb-popover-arrow-width;
-    left: 50%;
-    margin-left: -@gb-popover-arrow-width;
-    border-top-color: @gb-popover-border;
-    border-bottom-width: 0;
-
-    &:after {
-        bottom: 1px;
-        margin-left: -(@gb-popover-arrow-width - 1);
-        content: "";
-        border-top-color: #fff;
-        border-bottom-width: 0;
-    }
-}
-
-.popover-bottom .popover-arrow {
+// Arrow direction specific
+.popover-bottom .popover-arrow,
+.popover-bottom-left .popover-arrow,
+.popover-bottom-right .popover-arrow {
     top: -@gb-popover-arrow-width;
-    left: 50%;
     margin-left: -@gb-popover-arrow-width;
     border-top-width: 0;
     border-bottom-color: @gb-popover-border;
 
     &:after {
         top: 1px;
-        margin-left: -(@gb-popover-arrow-width - 1);
-        content: "";
         border-top-width: 0;
         border-bottom-color: @gb-popover-heading-background;
+        margin-left: -(@gb-popover-arrow-width - 1);
     }
 }
+.popover-top .popover-arrow,
+.popover-top-left .popover-arrow,
+.popover-top-right .popover-arrow {
+    bottom: -@gb-popover-arrow-width;
+    margin-left: -@gb-popover-arrow-width;
+    border-top-color: @gb-popover-border;
+    border-bottom-width: 0;
+
+    &:after {
+        bottom: 1px;
+        border-top-color: #fff;
+        border-bottom-width: 0;
+        margin-left: -(@gb-popover-arrow-width - 1);
+    }
+}
+
+.popover-bottom .popover-arrow,
+.popover-top .popover-arrow {
+    left: 50%;
+}
+.popover-bottom-left .popover-arrow,
+.popover-top-left .popover-arrow {
+    left: 90%;
+}
+.popover-bottom-right .popover-arrow,
+.popover-top-right .popover-arrow {
+    left: 10%;
+}
+// end - Arrow direction specific
 
 .popover-wrapper {
     .animation(scale-in, 0.15s, 1);
@@ -132,18 +146,55 @@
     .popover {
         position: absolute;
         z-index: @gb-zindex-popover;
-        transform: translateX(-50%);
-        left: 50%;
 
+        // Use padding so that there is no gap, when hovering from the element to the popover
         &.popover-top {
+            transform: translateX(-50%);
+            left: 50%;
             bottom: 100%;
-            // Use padding so that there is no gap, when hovering from the element to the popover
             padding-bottom: (@gb-popover-spacing + @gb-popover-arrow-width);
         }
-        &.popover-bottom {
+        &.popover-top-right {
+            transform: translateX(-10%);
+            left: 50%;
+            bottom: 100%;
+            padding-bottom: (@gb-popover-spacing + @gb-popover-arrow-width);
+        }
+        &.popover-right {
+            transform: translateY(50%);
+            bottom: 50%;
+            left: 100%;
+            padding-left: (@gb-popover-spacing + @gb-popover-arrow-width);
+        }
+        &.popover-bottom-right {
+            transform: translateX(-10%);
+            left: 50%;
             top: 100%;
-            // Use padding so that there is no gap, when hovering from the element to the popover
             padding-top: (@gb-popover-spacing + @gb-popover-arrow-width);
+        }
+        &.popover-bottom {
+            transform: translateX(-50%);
+            left: 50%;
+            top: 100%;
+            padding-top: (@gb-popover-spacing + @gb-popover-arrow-width);
+        }
+        &.popover-bottom-left {
+            transform: translateX(-90%);
+            left: 50%;
+            top: 100%;
+            padding-top: (@gb-popover-spacing + @gb-popover-arrow-width);
+        }
+        &.popover-left {
+            transform: translateY(50%);
+            bottom: 50%;
+            right: 100%;
+            padding-right: (@gb-popover-spacing + @gb-popover-arrow-width);
+        }
+        &.popover-top-left {
+            transform: translateX(-90%);
+            left: 50%;
+            bottom: 100%;
+            padding-bottom: (@gb-popover-spacing + @gb-popover-arrow-width);
         }
     }
 }

--- a/less/components/popover.less
+++ b/less/components/popover.less
@@ -132,6 +132,34 @@
 .popover-top-right .popover-arrow {
     left: 10%;
 }
+.popover-right .popover-arrow {
+    left: -@gb-popover-arrow-width;
+    margin-top: -@gb-popover-arrow-width;
+    border-left-width: 0;
+    border-right-color: @gb-popover-border;
+    top: 50%;
+
+    &:after {
+        left: 1px;
+        border-left-width: 0;
+        border-right-color: @gb-popover-heading-background;
+        margin-top: -(@gb-popover-arrow-width - 1);
+    }
+}
+.popover-left .popover-arrow {
+    right: -@gb-popover-arrow-width;
+    margin-top: -@gb-popover-arrow-width;
+    border-right-width: 0;
+    border-left-color: @gb-popover-border;
+    top: 50%;
+
+    &:after {
+        right: 1px;
+        border-right-width: 0;
+        border-left-color: @gb-popover-heading-background;
+        margin-top: -(@gb-popover-arrow-width - 1);
+    }
+}
 // end - Arrow direction specific
 
 .popover-wrapper {

--- a/pages/popovers.js
+++ b/pages/popovers.js
@@ -56,6 +56,33 @@ const EXAMPLE_BUTTON =
     </Popover>) : null}
 </Popover.Container>`;
 
+const EXAMPLE_POSITION =
+`<div>{
+    [
+        'top',
+        'top-right',
+        'right',
+        'bottom-right',
+        'bottom',
+        'bottom-left',
+        'left',
+        'top-left'
+    ].map(pos =>
+        <Popover.Container key={pos}
+                           onMouseEnter={() => this.setState({ [pos]: true })}
+                           onMouseLeave={() => this.setState({ [pos]: false })}>
+            <Button >
+                {pos}
+            </Button>
+            { this.state[pos] ?
+            <Popover position={pos}>
+                <Popover.Body>{pos}</Popover.Body>
+            </Popover>
+            : null }
+        </Popover.Container>
+    )
+}</div>`;
+
 export default () => {
     return (
         <Page title="Popovers" active="popovers">
@@ -74,6 +101,8 @@ export default () => {
             <Example title="With an input" source={EXAMPLE_WITH_INPUT} scope={SCOPE} />
 
             <Example title="With button and state" source={EXAMPLE_BUTTON} scope={SCOPE} />
+
+            <Example title="With custom positioning" source={EXAMPLE_POSITION} scope={SCOPE} />
         </Page>
     );
 };

--- a/src/Date.js
+++ b/src/Date.js
@@ -33,7 +33,7 @@ const DateSpan =  React.createClass({
     getDefaultProps() {
         return {
             format:  '',
-            refresh: 10*1000,
+            refresh: 10 * 1000,
             utc:     true
         };
     },

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -3,7 +3,16 @@ const classNames = require('classnames');
 
 const Link = require('./Link');
 
-const POSITIONS = ['bottom', 'top'];
+const POSITIONS = [
+    'top',
+    'top-right',
+    'right',
+    'bottom-right',
+    'bottom',
+    'bottom-left',
+    'left',
+    'top-left'
+];
 
 /**
  * Pop content with controls over content:
@@ -31,7 +40,7 @@ const Popover =  React.createClass({
 
     getDefaultProps() {
         return {
-            position: POSITIONS[0]
+            position: 'bottom'
         };
     },
 


### PR DESCRIPTION
Added 6 positions to the existing `top` and `bottom`:
```
    'top',
    'top-right',
    'right',
    'bottom-right',
    'bottom',
    'bottom-left',
    'left',
    'top-left'
```

Still missing the arrows for `left` and `right`

![popover-positions](https://cloud.githubusercontent.com/assets/5644953/22176056/0cbd3a5e-e002-11e6-9605-8286e127e6d0.gif)
