### PR TITLE
Add CountWidget component

### DIFF
--- a/less/components/count-widget.less
+++ b/less/components/count-widget.less
@@ -1,0 +1,56 @@
+.CountWidget {
+    display: inline-block;
+    vertical-align: middle;
+
+    .CountHalf {
+        position: relative;
+        float: left;
+        padding-bottom: @gb-padding-base-vertical;
+        text-align: right;
+
+        &:last-child {
+            text-align: left;
+            border-left: 1px solid @gb-palette-gray-darker;
+        }
+
+        .CountValue {
+            position: relative;
+            top: -1px;
+            display: block;
+            padding: 0 @gb-border-radius-base;
+            font-size: @gb-font-size-small;
+        }
+
+        .CountBar {
+            position: absolute;
+            min-width: @gb-border-radius-base;
+            height: 4px;
+        }
+
+        .CountBar-Left {
+            right: 0;
+            border-radius: @gb-border-radius-base 0 0 @gb-border-radius-base;
+
+            .CountMeter {
+                right: 0;
+                border-radius: @gb-border-radius-base 0 0 @gb-border-radius-base;
+            }
+        }
+
+        .CountBar-Right {
+            left: 0;
+            border-radius: 0 @gb-border-radius-base @gb-border-radius-base 0;
+
+            .CountMeter {
+                border-radius: 0 @gb-border-radius-base @gb-border-radius-base 0;
+            }
+        }
+
+        .CountMeter {
+            position: absolute;
+            height: 4px;
+            background-color: @gb-palette-gray;
+            width: 100%;
+        }
+    }
+}

--- a/less/main.less
+++ b/less/main.less
@@ -50,6 +50,7 @@
 @import "./components/tooltips.less";
 @import "./components/tree.less";
 @import "./components/icons.less";
+@import "./components/count-widget.less";
 
 @import "./layout/body.less";
 @import "./layout/footer.less";

--- a/src/CountWidget.js
+++ b/src/CountWidget.js
@@ -1,0 +1,45 @@
+const React = require('react');
+
+const CountWidget = React.createClass({
+    propTypes: {
+        left: React.PropTypes.number.isRequired,
+        right: React.PropTypes.number.isRequired,
+        // min-width for rendered element
+        minWidth: React.PropTypes.number
+    },
+
+    render() {
+        const { left, right, minWidth } = this.props;
+
+        // Total count
+        const total = left + right;
+
+        const countHalfStyle = {};
+        if (minWidth) {
+            countHalfStyle.minWidth = `${minWidth / 2}px`;
+        }
+
+        return (
+            <div className="CountWidget">
+                <div className="CountHalf" style={countHalfStyle}>
+                    <div className="CountValue">
+                        {left}
+                    </div>
+                    <span className="CountBar CountBar-Left" style={{ width: `${100 * left / total}%` }}>
+                        <div className="CountMeter" />
+                    </span>
+                </div>
+                <div className="CountHalf" style={countHalfStyle}>
+                    <div className="CountValue">
+                        {right}
+                    </div>
+                    <span className="CountBar CountBar-Right" style={{ width: `${100 * right / total}%` }}>
+                        <div className="CountMeter" />
+                    </span>
+                </div>
+            </div>
+        );
+    }
+});
+
+module.exports = CountWidget;


### PR DESCRIPTION
This PR adds a `CountWidget` component that allows to display a diff count between two measures.
This is quite similar to the GitHub branch commits diff element.

##### Basic

```jsx
<CountWidget left={...} right={...} minWidth={...} />
```
![image](https://cloud.githubusercontent.com/assets/7927876/22619865/0018c118-eafe-11e6-880e-de13ab0c45b6.png)


##### Tooltipped

```jsx
<Tooltip title="...">
    <CountWidget left={...} right={...} minWidth={...} />
</Tooltip>
```
![image](https://cloud.githubusercontent.com/assets/7927876/22619851/c76f2726-eafd-11e6-9e24-79275d0be3c1.png)
