### PR TITLE
Docker heroku deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git/
+node_modules/
+.next/
+Dockerfile
+Dockerfile.prebuild

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ static/images/logo
 static/css
 lib
 icons/*.js
+
+# Bob's prebuild
+.prebuild/

--- a/Bobfile
+++ b/Bobfile
@@ -1,0 +1,1 @@
+image: gitbook/styleguide

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:alpine
+
+# Import build
+ADD ./.prebuild/ /app/
+
+# Switch to /app folder
+WORKDIR /app
+
+# Production mode
+ENV NODE_ENV=production
+
+# Run
+CMD [ "/bin/sh", "-c", "./node_modules/.bin/next start -p ${PORT:-3000}" ]

--- a/Dockerfile.prebuild
+++ b/Dockerfile.prebuild
@@ -1,0 +1,28 @@
+FROM node:7.5.0
+
+# Add prebuild dir
+WORKDIR /prebuild/
+RUN mkdir -p /prebuild
+
+# Install yarn
+RUN npm i -g yarn
+
+# Yarn
+COPY ./yarn.lock ./package.json /prebuild/
+# Strip prepublish script to avoid errors
+RUN echo $(cat ./package.json | grep -v "prepublish") > ./package.json
+# Yarn install
+RUN yarn install
+
+# Rest of source
+COPY . /prebuild/
+
+# Build styleguide
+RUN npm run prepublish
+
+# Build next
+RUN ./node_modules/.bin/next build
+
+# Clean node_modules
+# TODO: add 'next' in prod
+# RUN rm -rf node_modules && yarn install --prod

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,19 +1,15 @@
 #!/bin/bash
 
 #
-# Deploy the documentation using "now"
-# We can't deploy the whole repository because the build script is being killed by now.
+# Deploy the styleguide to Heroku through docker
 #
 
-echo Building the documentation
-next build
+echo "Building container"
+bob build
 
-rm -rf .next/to-deploy
-mkdir -p .next/to-deploy
-cp -R .next/dist/* .next/to-deploy
+img=$(bob detect | head -n 1)
+heroku_img="registry.heroku.com/gitbook-styleguide/web"
 
-cp package.json .next/to-deploy/
-cp index.js .next/to-deploy/
-
-echo Deploying the documentation
-cd .next/to-deploy && now
+# Tag & push to heroku
+docker tag $img $heroku_img
+docker push $heroku_img


### PR DESCRIPTION
Allow the styleguide to be deployed to `heroku` using `next.js`. We use `heroku`'s new container support and run the build locally using `bob` and `docker`.

(`bob` allows to have a separate "build" with a lighter "prod" docker image).