### PR TITLE
Remove z-index on modals without backdrop

### DIFF
--- a/less/components/modals.less
+++ b/less/components/modals.less
@@ -23,6 +23,7 @@
     .box-shadow(@gb-modal-shadow);
 
     &.without-backdrop {
+        z-index: auto;
         border-color: @gb-palette-gray-outline;
         box-shadow: 0 1px 2px #ddd;
     }

--- a/pages/modals.js
+++ b/pages/modals.js
@@ -15,7 +15,7 @@ const EXAMPLE_IMPORT =
 'const Modal = require(\'gitbook-styleguide/lib/Modal\');';
 
 const EXAMPLE_DEFAULT =
-`<Modal animated={false}>
+`<Modal backdrop={false} animated={false}>
     <Modal.Heading title="Title" />
     <Modal.Body>
         Body of the modal


### PR DESCRIPTION
This fixes GitbookIO/feedback#362
(but not the root of the problem with popovers)